### PR TITLE
[Sprint 124] IFS-4578 Portierung in entkoppelten Baustein isy polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.0.0
+- `IFS-4578`: Portierung in entkoppelten Baustein isy-polling
+    - Portierung der Tickets IFS-4367, ISY-1025, IFS-3740 ins entkoppelte Repository
 # 4.0.0
 
 - `IFS-4262`: Alte Quellen aus isyfact-standards übernommen

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,32 @@
+# isy-polling
+
+## 5.0.0
+### Hinweise & bekannte Probleme
+
+### Umgesetzte Tickets
+#### Features
+- `IFS-4578`: Portierung in entkoppelten Baustein isy-polling
+  - Portierung der Tickets IFS-4367, ISY-1025, IFS-3740 ins entkoppelte Repository
+
+#### Bug Fixes
+
+#### Interne Anpassungen
+
+### Durchzuführende Aktionen vor dem ersten Einsatz
+
+### 4.0.0
+### Hinweise & bekannte Probleme
+
+### Umgesetzte Tickets
+#### Features
+- `IFS-4262`: Alte Quellen aus isyfact-standards übernommen
+- `IFS-4263`: Minimalistische POM erstellt
+- `IFS-4360`: Abhängigkeiten zu isyfact-standard entfernt
+
+#### Bug Fixes
+
+#### Interne Anpassungen
+
+### Durchzuführende Aktionen vor dem ersten Einsatz
+
+

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 name: isy-polling-doc
 title: isy-polling
-version: '4.0.0 SNAPSHOT'
-display_version: '4.0.0 SNAPSHOT'
+version: '5.0.0 SNAPSHOT'
+display_version: '5.0.0 SNAPSHOT'
 start_page: ROOT:konzept/master.adoc
 nav:
 - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/konzept/docinfo.adoc
+++ b/docs/modules/ROOT/pages/konzept/docinfo.adoc
@@ -1,8 +1,8 @@
 *Java Bibliothek / IT-System*
 
-[cols="5,2,3",options="header"]
+[cols="5m,2,3",options="header"]
 |====
 |Name |Art |Version
-m|isy-polling |Bibliothek |v{page-component-version}
+|isy-polling |Bibliothek |v{page-component-version}
 |====
 

--- a/license/NOTICE
+++ b/license/NOTICE
@@ -1,5 +1,5 @@
 This product contains software under the Copyright (c) 2016 of
-Bundesverwaltungsamt (BVA), Capgemini Deutschland GmbH.
+Bundesverwaltungsamt (BVA).
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").
 You may not use this product except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </scm>
 
     <properties>
-        <revision>4.0.0-SNAPSHOT</revision>
+        <revision>5.0.0-SNAPSHOT</revision>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.version>3.11.0</maven.compiler.version>


### PR DESCRIPTION
* docs: IFS-4578 remove service providers from NOTICE files
* chore: IFS-4578 update changelog
* chore: IFS-4578 add release notes to project
* docs: IFS-4578 unify table style
* build: IFS-4578 increase major version to 5.0.0-SNAPSHOT
* docs: IFS-4578 increase version to 5.0.0-SNAPSHOT